### PR TITLE
Fixing NaNs in Quadprog

### DIFF
--- a/quadprog/solve.QP.c
+++ b/quadprog/solve.QP.c
@@ -544,7 +544,7 @@ L100:
 		    d__3 = (d__1 = work[i__ - 1], abs(d__1)), d__4 = (d__2 = 
 			    work[i__], abs(d__2));
 		    gs = min(d__3,d__4);
-		    d__1 = gc * sqrt(gs * gs / (gc * gc) + 1);
+		    d__1 = gc * sqrt((gs / gc) * (gs / gc) + 1);
 		    temp = d_sign(&d__1, &work[i__ - 1]);
 		    gc = work[i__ - 1] / temp;
 		    gs = work[i__] / temp;
@@ -660,7 +660,7 @@ L797:
     d__3 = (d__1 = work[l1 - 1], abs(d__1)), d__4 = (d__2 = work[l1], abs(
 	    d__2));
     gs = min(d__3,d__4);
-    d__1 = gc * sqrt(gs * gs / (gc * gc) + 1);
+    d__1 = gc * sqrt((gs / gc) * (gs / gc) + 1);
     temp = d_sign(&d__1, &work[l1 - 1]);
     gc = work[l1 - 1] / temp;
     gs = work[l1] / temp;


### PR DESCRIPTION
I confirmed that NaNs are included in `sol` when running the following code: 

```python
import numpy as np
import quadprog

np.random.seed(1)

n = 66

X = np.full((n, n), 1e-20)
X[np.diag_indices_from(X)] = 1.0
Dmat = np.dot(X.T, X)
y = np.arange(1, n+1, dtype=float)
dvec = np.dot(X, y)

Amat = np.identity(n)
bvec = y + np.random.rand(n)

sol = quadprog.solve_qp(G=Dmat, a=y, C=Amat, b=bvec, meq=n)[0]

print(sol) # this gives all NaNs
```
So, I fixed the bug by referring to [the same discussion][1]. 

[1]: https://chasethedevil.github.io/post/quadprog-nans/
