### PR TITLE
Enable solving in parallel

### DIFF
--- a/quadprog/aind.c
+++ b/quadprog/aind.c
@@ -43,7 +43,7 @@
     integer ind_dim1, ind_offset, i__1, i__2;
 
     /* Local variables */
-    static integer i__, j;
+    integer i__, j;
 
     /* Parameter adjustments */
     ind_dim1 = *m;

--- a/quadprog/daxpy.c
+++ b/quadprog/daxpy.c
@@ -19,7 +19,7 @@
     integer i__1;
 
     /* Local variables */
-    static integer i__, m, ix, iy, mp1;
+    integer i__, m, ix, iy, mp1;
 
 /*     .. Scalar Arguments .. */
 /*     .. */

--- a/quadprog/ddot.c
+++ b/quadprog/ddot.c
@@ -20,8 +20,8 @@ doublereal ddot_(integer *n, doublereal *dx, integer *incx, doublereal *dy,
     doublereal ret_val;
 
     /* Local variables */
-    static integer i__, m, ix, iy, mp1;
-    static doublereal dtemp;
+    integer i__, m, ix, iy, mp1;
+    doublereal dtemp;
 
 /*     .. Scalar Arguments .. */
 /*     .. */

--- a/quadprog/dpofa.c
+++ b/quadprog/dpofa.c
@@ -26,9 +26,9 @@ static integer c__1 = 1;
     double sqrt(doublereal);
 
     /* Local variables */
-    static integer j, k;
-    static doublereal s, t;
-    static integer jm1;
+    integer j, k;
+    doublereal s, t;
+    integer jm1;
     extern doublereal ddot_(integer *, doublereal *, integer *, doublereal *, 
 	    integer *);
 

--- a/quadprog/dscal.c
+++ b/quadprog/dscal.c
@@ -19,7 +19,7 @@
     integer i__1, i__2;
 
     /* Local variables */
-    static integer i__, m, mp1, nincx;
+    integer i__, m, mp1, nincx;
 
 /*     .. Scalar Arguments .. */
 /*     .. */

--- a/quadprog/solve.QP.c
+++ b/quadprog/solve.QP.c
@@ -106,19 +106,19 @@
     double sqrt(doublereal), d_sign(doublereal *, doublereal *);
 
     /* Local variables */
-    static integer i__, j, l, r__, l1;
-    static doublereal t1, gc, gs, nu, tt;
-    static integer it1, nvl;
-    static doublereal sum;
-    static integer info;
-    static doublereal tmpa, tmpb, temp;
-    static integer iwrm, iwrv, iwsv, iwuv, iwzv;
-    static logical t1inf, t2min;
+    integer i__, j, l, r__, l1;
+    doublereal t1, gc, gs, nu, tt;
+    integer it1, nvl;
+    doublereal sum;
+    integer info;
+    doublereal tmpa, tmpb, temp;
+    integer iwrm, iwrv, iwsv, iwuv, iwzv;
+    logical t1inf, t2min;
     extern /* Subroutine */ int dpofa_(doublereal *, integer *, integer *, 
 	    integer *), dpori_(doublereal *, integer *, integer *), dposl_(
 	    doublereal *, integer *, integer *, doublereal *);
-    static integer iwnbv;
-    static doublereal vsmall;
+    integer iwnbv;
+    doublereal vsmall;
 
     /* Parameter adjustments */
     --dvec;

--- a/quadprog/util.c
+++ b/quadprog/util.c
@@ -22,9 +22,9 @@ static integer c__1 = 1;
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer j, k;
-    static doublereal t;
-    static integer kp1;
+    integer j, k;
+    doublereal t;
+    integer kp1;
     extern /* Subroutine */ int dscal_(integer *, doublereal *, doublereal *, 
 	    integer *), daxpy_(integer *, doublereal *, doublereal *, integer 
 	    *, doublereal *, integer *);
@@ -112,9 +112,9 @@ L90:
     integer a_dim1, a_offset, i__1, i__2;
 
     /* Local variables */
-    static integer k;
-    static doublereal t;
-    static integer kb;
+    integer k;
+    doublereal t;
+    integer kb;
     extern doublereal ddot_(integer *, doublereal *, integer *, doublereal *, 
 	    integer *);
     extern /* Subroutine */ int daxpy_(integer *, doublereal *, doublereal *, 


### PR DESCRIPTION
This PR releases the global interpreter lock while solving, allowing multiple invocations within a single Python process to run in parallel.

I have manually removed `static` declarations from the generated C code so that it is thread-safe. You may wish to consider regenerating the C code passing the `-a` option to `f2c`.